### PR TITLE
Don't play without bars

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -14,7 +14,7 @@
             <v-btn @click="playPause"
               ><v-icon large>{{ playPauseButton.icon }}</v-icon></v-btn
             >
-            <v-btn @click="playbackInterface.rewind()"><v-icon large>mdi-rewind</v-icon></v-btn>
+            <v-btn @click="rewind()"><v-icon large>mdi-rewind</v-icon></v-btn>
           </div>
         </v-card>
         <v-card class="ml-6">
@@ -91,11 +91,17 @@ export default {
   methods: {
     playPause() {
       if (this.playPauseButton.status === "paused") {
-        this.playbackInterface.startPlaying();
-        this.playPauseButton.status = "playing";
-        this.playPauseButton.icon = "mdi-pause";
-        this.selectMode("home");
-        this.menuData.tabSelected = 0;
+        if (getters.getBarCount() > 0) {
+          this.playbackInterface.startPlaying();
+          this.playPauseButton.status = "playing";
+          this.playPauseButton.icon = "mdi-pause";
+          this.selectMode("home");
+          this.menuData.tabSelected = 0;
+        }
+        else {
+          // take some action corresponding to there being no bars and play being clicked
+          console.log("no bars so cannot play")
+        }
       } else {
         this.playbackInterface.pausePlaying();
         this.playPauseButton.status = "paused";
@@ -106,6 +112,14 @@ export default {
       if (this.playPauseButton.status === "playing") {
         this.playPauseButton.status = "paused";
         this.playPauseButton.icon = "mdi-play";
+      }
+    },
+    rewind() {
+      if (getters.getBarCount() > 0) {
+        this.playbackInterface.rewind()
+      }
+      else {
+        console.log("no bars so cannot rewind")
       }
     },
     deleteBar(barNumber) {


### PR DESCRIPTION
No longer gives an error when trying to play without bars, just does nothing. Similar for rewind.

`if`-statements for each; now just needs the `else` branch for each to be filled by some action - highlight add (+) button or something similar.